### PR TITLE
minimum required version of cmake changed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # ------------------------------------------------------------------------------------------------
 
-cmake_minimum_required( VERSION 3.8 )
+cmake_minimum_required( VERSION 3.17 )
 
 project( Malmo )
 


### PR DESCRIPTION
There was problem with building VereyaPython using cmake versions below 3.17.