### PR TITLE
init support for some reward handlers

### DIFF
--- a/src/main/java/io/singularitynet/Client/ClientStateMachine.java
+++ b/src/main/java/io/singularitynet/Client/ClientStateMachine.java
@@ -25,10 +25,7 @@ import io.singularitynet.*;
 import io.singularitynet.MissionHandlerInterfaces.IVideoProducer;
 import io.singularitynet.MissionHandlerInterfaces.IWantToQuit;
 import io.singularitynet.MissionHandlerInterfaces.IWorldGenerator;
-import io.singularitynet.MissionHandlers.DrawImplementation;
-import io.singularitynet.MissionHandlers.MissionBehaviour;
-import io.singularitynet.MissionHandlers.MultidimensionalReward;
-import io.singularitynet.MissionHandlers.RewardForSendingCommandImplementation;
+import io.singularitynet.MissionHandlers.*;
 import io.singularitynet.Server.VereyaModServer;
 import io.singularitynet.mixin.ClientWorldMixinAccess;
 import io.singularitynet.mixin.LevelStorageMixin;
@@ -1872,8 +1869,8 @@ public class ClientStateMachine extends StateMachine implements IVereyaMessageLi
 
                 // Get the final reward data:
                 ClientAgentConnection cac = currentMissionInit().getClientAgentConnection();
-                /*if (currentMissionBehaviour() != null && currentMissionBehaviour().rewardProducer != null && cac != null)
-                    currentMissionBehaviour().rewardProducer.getReward(currentMissionInit(), ClientStateMachine.this.finalReward);*/
+                if (currentMissionBehaviour() != null && currentMissionBehaviour().rewardProducer != null && cac != null)
+                    currentMissionBehaviour().rewardProducer.getReward(ClientStateMachine.this.finalReward);
 
                 // Now send a message to the server saying that we have finished our mission:
                 List<AgentSection> agents = currentMissionInit().getMission().getAgentSection();
@@ -2024,7 +2021,7 @@ public class ClientStateMachine extends StateMachine implements IVereyaMessageLi
                 if (command != null) LOGGER.debug("Command " + command);
                 boolean handled = handleCommand(command);
                 //trigger the reward for sending a command
-                if (handled) currentMissionBehaviour().rewardProducer.trigger(RewardForSendingCommandImplementation.class);
+                if (handled) currentMissionBehaviour().rewardProducer.trigger(CommandBase.class);
                 if ((command != null) && !handled){
                     LOGGER.warn("Command " + command + " not handled");
                 }
@@ -2074,9 +2071,10 @@ public class ClientStateMachine extends StateMachine implements IVereyaMessageLi
                     System.out.println("Failed to get properties - final reward may go missing.");
                 }*/
                 // Get the final reward data:
-                ClientAgentConnection cac = currentMissionInit().getClientAgentConnection();
+                ClientAgentConnection cac = currentMissionInit().getClientAgentConnection();/*
                 if (currentMissionBehaviour() != null && currentMissionBehaviour().rewardProducer != null && cac != null)
-                    currentMissionBehaviour().rewardProducer.getReward(ClientStateMachine.this.finalReward);
+                    currentMissionBehaviour().rewardProducer.getReward(CurrentMissionInit(), ClientStateMachine.this.finalReward);
+                    */
 
 
                 onMissionEnded(ClientState.MISSION_ENDED, null);

--- a/src/main/java/io/singularitynet/Client/ClientStateMachine.java
+++ b/src/main/java/io/singularitynet/Client/ClientStateMachine.java
@@ -2021,7 +2021,9 @@ public class ClientStateMachine extends StateMachine implements IVereyaMessageLi
                 if (command != null) LOGGER.debug("Command " + command);
                 boolean handled = handleCommand(command);
                 //trigger the reward for sending a command
-                if (handled) currentMissionBehaviour().rewardProducer.trigger(CommandBase.class);
+                if (handled && currentMissionBehaviour().rewardProducer != null){
+                    currentMissionBehaviour().rewardProducer.trigger(CommandBase.class);
+                }
                 if ((command != null) && !handled){
                     LOGGER.warn("Command " + command + " not handled");
                 }

--- a/src/main/java/io/singularitynet/Client/ClientStateMachine.java
+++ b/src/main/java/io/singularitynet/Client/ClientStateMachine.java
@@ -28,6 +28,7 @@ import io.singularitynet.MissionHandlerInterfaces.IWorldGenerator;
 import io.singularitynet.MissionHandlers.DrawImplementation;
 import io.singularitynet.MissionHandlers.MissionBehaviour;
 import io.singularitynet.MissionHandlers.MultidimensionalReward;
+import io.singularitynet.MissionHandlers.RewardForSendingCommandImplementation;
 import io.singularitynet.Server.VereyaModServer;
 import io.singularitynet.mixin.ClientWorldMixinAccess;
 import io.singularitynet.mixin.LevelStorageMixin;
@@ -1952,23 +1953,22 @@ public class ClientStateMachine extends StateMachine implements IVereyaMessageLi
 
             // Minecraft.getMinecraft().mcProfiler.endStartSection("malmoGatherRewardSignal");
             // Now create the reward signal:
-            /*
             if (currentMissionBehaviour() != null && currentMissionBehaviour().rewardProducer != null && cac != null)
             {
                 MultidimensionalReward reward = new MultidimensionalReward();
-                currentMissionBehaviour().rewardProducer.getReward(currentMissionInit(), reward);
+                currentMissionBehaviour().rewardProducer.getReward(reward);
                 if (!reward.isEmpty())
                 {
                     String strReward = reward.getAsSimpleString();
-                    Minecraft.getMinecraft().mcProfiler.startSection("malmoSendTCPReward");
+//                    Minecraft.getMinecraft().mcProfiler.startSection("malmoSendTCPReward");
 
-                    ScoreHelper.logReward(strReward);
+//                    ScoreHelper.logReward(strReward);
 
                     if (AddressHelper.getMissionControlPort() == 0) {
                         // MalmoEnvServer - reward
-                        if (envServer != null) {
-                            envServer.addRewards(reward.getRewardTotal());
-                        }
+//                        if (envServer != null) {
+//                            envServer.addRewards(reward.getRewardTotal());
+//                        }
                     } else {
                         if (this.rewardSocket.sendTCPString(strReward)) {
                             this.failedTCPRewardSendCount = 0; // Reset the count of consecutive TCP failures.
@@ -1978,13 +1978,12 @@ public class ClientStateMachine extends StateMachine implements IVereyaMessageLi
                             // the agent cleanly, so tends to kill the process.)
                             this.failedTCPRewardSendCount++;
                             TCPUtils.Log(Level.WARNING, "Reward signal delivery failure count at " + this.failedTCPRewardSendCount);
-                            ClientStateMachine.this.getScreenHelper().addFragment("ERROR: Agent missed reward signal", TextCategory.TXT_CLIENT_WARNING, 5000);
+//                            ClientStateMachine.this.getScreenHelper().addFragment("ERROR: Agent missed reward signal", TextCategory.TXT_CLIENT_WARNING, 5000);
                         }
                     }
                 }
             }
-            Minecraft.getMinecraft().mcProfiler.endSection();
-            */
+//            Minecraft.getMinecraft().mcProfiler.endSection();
             int maxFailedTCPSendCount = 0;
             for (VideoHook hook : this.videoHooks)
             {
@@ -2023,6 +2022,8 @@ public class ClientStateMachine extends StateMachine implements IVereyaMessageLi
                 // Pass the command to our various control overrides:
                 // Minecraft.getMinecraft().mcProfiler.startSection("malmoCommandAct");
                 if (command != null) LOGGER.debug("Command " + command);
+                //handle reward for sending command
+                if (command != null) currentMissionBehaviour().rewardProducer.produceReward(RewardForSendingCommandImplementation.class);
                 boolean handled = handleCommand(command);
                 if ((command != null) && !handled){
                     LOGGER.warn("Command " + command + " not handled");

--- a/src/main/java/io/singularitynet/Client/ClientStateMachine.java
+++ b/src/main/java/io/singularitynet/Client/ClientStateMachine.java
@@ -2022,9 +2022,9 @@ public class ClientStateMachine extends StateMachine implements IVereyaMessageLi
                 // Pass the command to our various control overrides:
                 // Minecraft.getMinecraft().mcProfiler.startSection("malmoCommandAct");
                 if (command != null) LOGGER.debug("Command " + command);
-                //handle reward for sending command
-                if (command != null) currentMissionBehaviour().rewardProducer.produceReward(RewardForSendingCommandImplementation.class);
                 boolean handled = handleCommand(command);
+                //trigger the reward for sending a command
+                if (handled) currentMissionBehaviour().rewardProducer.trigger(RewardForSendingCommandImplementation.class);
                 if ((command != null) && !handled){
                     LOGGER.warn("Command " + command + " not handled");
                 }
@@ -2074,10 +2074,10 @@ public class ClientStateMachine extends StateMachine implements IVereyaMessageLi
                     System.out.println("Failed to get properties - final reward may go missing.");
                 }*/
                 // Get the final reward data:
-                ClientAgentConnection cac = currentMissionInit().getClientAgentConnection();/*
+                ClientAgentConnection cac = currentMissionInit().getClientAgentConnection();
                 if (currentMissionBehaviour() != null && currentMissionBehaviour().rewardProducer != null && cac != null)
-                    currentMissionBehaviour().rewardProducer.getReward(currentMissionInit(), ClientStateMachine.this.finalReward);
-                    */
+                    currentMissionBehaviour().rewardProducer.getReward(ClientStateMachine.this.finalReward);
+
 
                 onMissionEnded(ClientState.MISSION_ENDED, null);
             } else if (messageType == VereyaMessageType.SERVER_GO) {

--- a/src/main/java/io/singularitynet/MissionHandlerInterfaces/IRewardProducer.java
+++ b/src/main/java/io/singularitynet/MissionHandlerInterfaces/IRewardProducer.java
@@ -1,8 +1,11 @@
 package io.singularitynet.MissionHandlerInterfaces;
 
+import io.singularitynet.MissionHandlers.MultidimensionalReward;
 import io.singularitynet.projectmalmo.MissionInit;
 
 public interface IRewardProducer {
     public void cleanup();
     public void prepare(MissionInit missionInit);
+    public void getReward(MultidimensionalReward reward);
+    public void produceReward(Class<? extends IRewardProducer> clazz);
 }

--- a/src/main/java/io/singularitynet/MissionHandlerInterfaces/IRewardProducer.java
+++ b/src/main/java/io/singularitynet/MissionHandlerInterfaces/IRewardProducer.java
@@ -7,5 +7,5 @@ public interface IRewardProducer {
     public void cleanup();
     public void prepare(MissionInit missionInit);
     public void getReward(MultidimensionalReward reward);
-    public void produceReward(Class<? extends IRewardProducer> clazz);
+    public void trigger(Class<? extends IRewardProducer> clazz);
 }

--- a/src/main/java/io/singularitynet/MissionHandlerInterfaces/IRewardProducer.java
+++ b/src/main/java/io/singularitynet/MissionHandlerInterfaces/IRewardProducer.java
@@ -7,5 +7,5 @@ public interface IRewardProducer {
     public void cleanup();
     public void prepare(MissionInit missionInit);
     public void getReward(MultidimensionalReward reward);
-    public void trigger(Class<? extends IRewardProducer> clazz);
+    public void trigger(Class<?> clazz);
 }

--- a/src/main/java/io/singularitynet/MissionHandlers/MissionBehaviour.java
+++ b/src/main/java/io/singularitynet/MissionHandlers/MissionBehaviour.java
@@ -199,7 +199,7 @@ public class MissionBehaviour implements IMissionBehaviour {
     }
 
     public void addRewardProducer(IRewardProducer handler)
-    {/*
+    {
         if (this.rewardProducer == null)
             this.rewardProducer = handler;
         else
@@ -212,7 +212,7 @@ public class MissionBehaviour implements IMissionBehaviour {
                 this.rewardProducer = group;
             }
             ((RewardGroup) this.rewardProducer).addRewardProducer(handler);
-        }*/
+        }
     }
 
     public void addObservationProducer(IObservationProducer handler)

--- a/src/main/java/io/singularitynet/MissionHandlers/RewardForSendingCommandImplementation.java
+++ b/src/main/java/io/singularitynet/MissionHandlers/RewardForSendingCommandImplementation.java
@@ -63,8 +63,8 @@ public class RewardForSendingCommandImplementation extends HandlerBase implement
     }
 
     @Override
-    public void trigger(Class<? extends IRewardProducer> clazz) {
-        if (clazz.isInstance(this)){
+    public void trigger(Class<?> clazz) {
+        if (clazz.equals(CommandBase.class)){
             this.triggerFlag();
         }
     }

--- a/src/main/java/io/singularitynet/MissionHandlers/RewardForSendingCommandImplementation.java
+++ b/src/main/java/io/singularitynet/MissionHandlers/RewardForSendingCommandImplementation.java
@@ -63,7 +63,7 @@ public class RewardForSendingCommandImplementation extends HandlerBase implement
     }
 
     @Override
-    public void produceReward(Class<? extends IRewardProducer> clazz) {
+    public void trigger(Class<? extends IRewardProducer> clazz) {
         if (clazz.isInstance(this)){
             this.triggerFlag();
         }

--- a/src/main/java/io/singularitynet/MissionHandlers/RewardForSendingCommandImplementation.java
+++ b/src/main/java/io/singularitynet/MissionHandlers/RewardForSendingCommandImplementation.java
@@ -1,0 +1,71 @@
+package io.singularitynet.MissionHandlers;
+
+import io.singularitynet.MissionHandlerInterfaces.IRewardProducer;
+import io.singularitynet.projectmalmo.MissionInit;
+import io.singularitynet.projectmalmo.RewardForSendingCommand;
+
+import java.math.BigDecimal;
+
+public class RewardForSendingCommandImplementation extends HandlerBase implements IRewardProducer {
+
+    BigDecimal reward;
+    String distribution;
+    Integer dimension;
+    boolean triggered;
+
+    public RewardForSendingCommandImplementation(){
+        this.reward = null;
+        this.distribution = null;
+        this.dimension = null;
+        this.triggered = false;
+    }
+
+    public void triggerFlag(){
+        this.triggered = true;
+    }
+
+    public void resetFlag(){
+        this.triggered = false;
+    }
+
+    public boolean isTriggered(){
+        return this.triggered;
+    }
+
+    @Override
+    public boolean parseParameters(Object params){
+        if (params == null || !(params instanceof RewardForSendingCommand)) {
+            return false;
+        }
+        RewardForSendingCommand rscparams = (RewardForSendingCommand)params;
+        this.reward = rscparams.getReward();
+        this.distribution = rscparams.getDistribution();
+        this.dimension = rscparams.getDimension();
+        return true;
+    }
+
+    @Override
+    public void cleanup() {
+
+    }
+
+    @Override
+    public void prepare(MissionInit missionInit) {
+
+    }
+
+    @Override
+    public void getReward(MultidimensionalReward reward) {
+        if (this.isTriggered()){
+            reward.add(this.dimension, this.reward.floatValue());
+            this.resetFlag();
+        }
+    }
+
+    @Override
+    public void produceReward(Class<? extends IRewardProducer> clazz) {
+        if (clazz.isInstance(this)){
+            this.triggerFlag();
+        }
+    }
+}

--- a/src/main/java/io/singularitynet/MissionHandlers/RewardForTouchingBlockTypeImplementation.java
+++ b/src/main/java/io/singularitynet/MissionHandlers/RewardForTouchingBlockTypeImplementation.java
@@ -1,0 +1,57 @@
+package io.singularitynet.MissionHandlers;
+
+import io.singularitynet.MissionHandlerInterfaces.IRewardProducer;
+import io.singularitynet.projectmalmo.BlockSpecWithDescription;
+import io.singularitynet.projectmalmo.BlockSpecWithRewardAndBehaviour;
+import io.singularitynet.projectmalmo.MissionInit;
+import io.singularitynet.projectmalmo.RewardForTouchingBlockType;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+public class RewardForTouchingBlockTypeImplementation extends HandlerBase implements IRewardProducer {
+
+    HashMap<String, BlockSpecWithRewardAndBehaviour> rewardBlocks;
+    HashSet<String> onceOnlyBlocks;
+
+    public RewardForTouchingBlockTypeImplementation(){
+        this.rewardBlocks = new HashMap<String, BlockSpecWithRewardAndBehaviour>();
+        this.onceOnlyBlocks = new HashSet<String>();
+    }
+
+    @Override
+    public void cleanup() {
+
+    }
+
+    @Override
+    public boolean parseParameters(Object params){
+        if (params == null || !(params instanceof RewardForTouchingBlockType)) {
+            return false;
+        }
+        RewardForTouchingBlockType rtbparams = (RewardForTouchingBlockType)params;
+        List<BlockSpecWithRewardAndBehaviour> blocks = rtbparams.getBlock();
+        if (this.rewardBlocks == null) this.rewardBlocks = new HashMap<String, BlockSpecWithRewardAndBehaviour>();
+        for (BlockSpecWithRewardAndBehaviour block : blocks){
+            String blockType = block.getType().getFirst().toString().toLowerCase();
+            this.rewardBlocks.put(blockType, block);
+        }
+        return true;
+    }
+
+    @Override
+    public void prepare(MissionInit missionInit) {
+
+    }
+
+    @Override
+    public void getReward(MultidimensionalReward reward) {
+
+    }
+
+    @Override
+    public void produceReward(Class<? extends IRewardProducer> clazz) {
+
+    }
+}

--- a/src/main/java/io/singularitynet/MissionHandlers/RewardForTouchingBlockTypeImplementation.java
+++ b/src/main/java/io/singularitynet/MissionHandlers/RewardForTouchingBlockTypeImplementation.java
@@ -67,7 +67,7 @@ public class RewardForTouchingBlockTypeImplementation extends HandlerBase implem
     }
 
     @Override
-    public void trigger(Class<? extends IRewardProducer> clazz) {
+    public void trigger(Class<?> clazz) {
 
     }
 

--- a/src/main/java/io/singularitynet/MissionHandlers/RewardForTouchingBlockTypeImplementation.java
+++ b/src/main/java/io/singularitynet/MissionHandlers/RewardForTouchingBlockTypeImplementation.java
@@ -64,6 +64,7 @@ public class RewardForTouchingBlockTypeImplementation extends HandlerBase implem
             this.onceOnlyBlocks.add(blockType);
         }
         reward.add(this.dimension, rewardBlock.getReward().floatValue());
+        // TODO: implement other behaviours
     }
 
     @Override

--- a/src/main/java/io/singularitynet/MissionHandlers/RewardGroup.java
+++ b/src/main/java/io/singularitynet/MissionHandlers/RewardGroup.java
@@ -68,9 +68,9 @@ public class RewardGroup extends HandlerBase implements IRewardProducer{
     }
 
     @Override
-    public void produceReward(Class<? extends IRewardProducer> clazz) {
+    public void trigger(Class<? extends IRewardProducer> clazz) {
         for (IRewardProducer han : this.handlers){
-            han.produceReward(clazz);
+            han.trigger(clazz);
         }
     }
 }

--- a/src/main/java/io/singularitynet/MissionHandlers/RewardGroup.java
+++ b/src/main/java/io/singularitynet/MissionHandlers/RewardGroup.java
@@ -68,7 +68,7 @@ public class RewardGroup extends HandlerBase implements IRewardProducer{
     }
 
     @Override
-    public void trigger(Class<? extends IRewardProducer> clazz) {
+    public void trigger(Class<?> clazz) {
         for (IRewardProducer han : this.handlers){
             han.trigger(clazz);
         }

--- a/src/main/java/io/singularitynet/MissionHandlers/RewardGroup.java
+++ b/src/main/java/io/singularitynet/MissionHandlers/RewardGroup.java
@@ -1,0 +1,76 @@
+package io.singularitynet.MissionHandlers;
+
+import io.singularitynet.MissionHandlerInterfaces.IRewardProducer;
+import io.singularitynet.projectmalmo.MissionInit;
+
+import java.util.ArrayList;
+
+public class RewardGroup extends HandlerBase implements IRewardProducer{
+
+    private ArrayList<IRewardProducer> handlers;
+    private boolean shareParametersWithChildren = false;
+
+    public RewardGroup(){ this.handlers = new ArrayList<IRewardProducer>();}
+
+    protected void setShareParametersWithChildren(boolean share)
+    {
+        this.shareParametersWithChildren = share;
+    }
+
+    public void addRewardProducer(IRewardProducer handler){
+        this.handlers.add(handler);
+    }
+
+    public boolean isFixed(){
+        return false;
+    }
+
+    @Override
+    public void setParentBehaviour(MissionBehaviour mb)
+    {
+        super.setParentBehaviour(mb);
+        for (IRewardProducer han : this.handlers)
+            ((HandlerBase)han).setParentBehaviour(mb);
+    }
+
+    @Override
+    public boolean parseParameters(Object params) {
+        // Normal handling:
+        boolean ok = super.parseParameters(params);
+
+        // Now, pass the params to each child handler, if that was requested:
+        if (this.shareParametersWithChildren) {
+            // AND the results, but without short-circuit evaluation.
+            for (IRewardProducer han : this.handlers) {
+                if (han instanceof HandlerBase) {
+                    ok &= ((HandlerBase) han).parseParameters(params);
+                }
+            }
+        }
+        return ok;
+    }
+
+    @Override
+    public void cleanup() {
+
+    }
+
+    @Override
+    public void prepare(MissionInit missionInit) {
+
+    }
+
+    @Override
+    public void getReward(MultidimensionalReward reward) {
+        for (IRewardProducer han : this.handlers){
+            han.getReward(reward);
+        }
+    }
+
+    @Override
+    public void produceReward(Class<? extends IRewardProducer> clazz) {
+        for (IRewardProducer han : this.handlers){
+            han.produceReward(clazz);
+        }
+    }
+}


### PR DESCRIPTION
I am currently trying to implement reward handlers (RewardForSendingCommand and RewardForTouchingBlockType). I have stumbled upon a problem when rewards should be triggered on the same tick when agent quits the mission. For example, i am running cliff_walking example. Missions ends when agent touches the lava. Thus, mission ends but no reward for sending a command is triggered. The same thing with RewardForTouchingBlockType, at first agent touches the lava, mission ends and no reward for touching lava is triggered.
For the first implementation i uncommented this code in ClientStateMachine.MissionRunningEpisode.sendData() and modified getReward() a bit:
```java
// Now create the reward signal:
if (currentMissionBehaviour() != null && currentMissionBehaviour().rewardProducer != null && cac != null)
            {
                MultidimensionalReward reward = new MultidimensionalReward();
                currentMissionBehaviour().rewardProducer.getReward(reward);
                if (!reward.isEmpty())
                {
                    String strReward = reward.getAsSimpleString();
//                    Minecraft.getMinecraft().mcProfiler.startSection("malmoSendTCPReward");

//                    ScoreHelper.logReward(strReward);

                    if (AddressHelper.getMissionControlPort() == 0) {
                        // MalmoEnvServer - reward
//                        if (envServer != null) {
//                            envServer.addRewards(reward.getRewardTotal());
//                        }
```
Also, i noticed there's a code for getting rewards with a message of ended mission
```java
private void sendMissionEnded(MissionEnded missionEnded)
        {
            // Send a MissionEnded message to the agent to inform it that the mission has ended.
            // Create a string XML representation:
            String missionEndedString = null;
            try
            {
                missionEndedString = SchemaHelper.serialiseObject(missionEnded, MissionEnded.class);
                
                if (ScoreHelper.isScoring()) {
                    Reward reward = missionEnded.getReward();
                    if (reward == null) {
                        reward = new Reward();
                    }
                    ScoreHelper.logMissionEndRewards(reward);
                }
            }
```

I tried to uncomment it as well but at first glance it did nothing. Perhaps, MissionEnded class should be modified or re-implemented? If i got it right, it is a class from Malmo and needs some modifications to work with Vereya.

I would like to get some advices @CICS-Oleg @noskill 